### PR TITLE
feat(xp): add XP module, idempotent event handling, mapping, tests, and migrations

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -38,6 +38,24 @@ $ npm install
 $ npm run start
 
 # watch mode
+
+## XP Module (contribution notes)
+
+This project includes an `XPModule` to support gamified progression. Suggested accrual mechanics:
+
+- Messaging: +5 XP per message (deduplicate by message hash)
+- Token send: +10 XP per token transfer
+- First message of the day: bonus +20 XP
+- Gifting an NFT/collectible: +25 XP
+- Daily login streaks: exponential bonus (2% per day capped)
+
+Stellar events should be validated (e.g., check message hash on-chain) before granting XP. The `XPModule` stores data in PostgreSQL and exposes endpoints:
+
+- `GET /xp/:userId` — returns current XP for a user
+- `POST /xp/add` — adds XP (used by internal event processors/tests)
+
+When implementing accrual logic, prefer idempotent operations and event deduplication to avoid double-counting.
+
 $ npm run start:dev
 
 # production mode

--- a/backend/migrations/1680000000000-CreateXpAndProcessedEventAndStellarAccount.sql
+++ b/backend/migrations/1680000000000-CreateXpAndProcessedEventAndStellarAccount.sql
@@ -1,0 +1,22 @@
+-- Migration: create xp, processed_event, stellar_account tables
+
+CREATE TABLE IF NOT EXISTS "xp" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "userId" varchar(255) NOT NULL,
+  "xpValue" integer NOT NULL DEFAULT 0,
+  "createdAt" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS "processed_event" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "eventId" varchar(255) NOT NULL UNIQUE,
+  "source" varchar(255),
+  "createdAt" timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS "stellar_account" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "stellarAccount" varchar(255) NOT NULL UNIQUE,
+  "userId" varchar(255),
+  "createdAt" timestamptz NOT NULL DEFAULT now()
+);

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json"
+  ,"migrate": "for f in migrations/*.sql; do psql \"$${DB_CONN_STRING:-postgresql://$${DB_USER:-postgres}:$${DB_PASSWORD:-postgres}@$${DB_HOST:-localhost}:$${DB_PORT:-5432}/$${DB_NAME:-whspr}}\" -f \"$f\"; done"
   },
   "dependencies": {
     "@nestjs/common": "^11.1.6",

--- a/backend/src/app.controller.spec.ts
+++ b/backend/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return "Whisper API"', () => {
+      expect(appController.getHello()).toBe('Whisper API');
     });
   });
 });

--- a/backend/src/xp/README.md
+++ b/backend/src/xp/README.md
@@ -1,0 +1,25 @@
+XP Module
+
+Purpose
+- Manage user experience points (XP) accrued from on-chain and app events.
+
+Entities
+- Xp: stores per-user XP totals (`id`, `userId`, `xpValue`, `createdAt`).
+- ProcessedEvent: dedupes processed Stellar events to ensure idempotency (`eventId`).
+- StellarAccount: maps on-chain Stellar addresses to internal `userId`.
+
+Endpoints
+- GET `/xp/:userId` — returns `{ userId, xp }`.
+- POST `/xp/add` — body `AddXpDto` `{ userId, amount, source? }`.
+- POST `/xp/event` — body `StellarEventDto` `{ eventId, type, userId, data? }`.
+- POST `/xp/map-account` — body `MapStellarAccountDto` `{ stellarAccount, userId? }`.
+
+Accrual Mechanics (suggested)
+- Message: +5 XP per message event.
+- Token send: +10 XP per token send.
+- Optional multipliers: first-time bonus, daily caps, or streak bonuses.
+
+Operational notes
+- The service uses a transaction and `processed_event` table to avoid double-awarding.
+- For production, run SQL migrations in `backend/migrations` and disable `synchronize`.
+- Protect `/xp/event` and `/xp/map-account` endpoints with auth/signatures.

--- a/backend/src/xp/dto/add-xp.dto.ts
+++ b/backend/src/xp/dto/add-xp.dto.ts
@@ -1,0 +1,37 @@
+import { IsUUID, IsInt, Min, IsString, IsOptional } from 'class-validator';
+
+export class AddXpDto {
+  @IsUUID()
+  userId!: string;
+
+  @IsInt()
+  @Min(0)
+  amount!: number;
+
+  // optional reason or source (e.g., "message", "token_send")
+  source?: string;
+}
+
+export class StellarEventDto {
+  @IsString()
+  eventId!: string;
+
+  @IsString()
+  type!: string;
+
+  // This represents the Stellar account (e.g. G...) or an internal userId;
+  // accept string here because events from Horizon will use Stellar public keys.
+  @IsString()
+  userId!: string;
+
+  data?: any;
+}
+
+export class MapStellarAccountDto {
+  @IsString()
+  stellarAccount!: string;
+
+  @IsOptional()
+  @IsUUID()
+  userId?: string;
+}

--- a/backend/src/xp/dto/get-xp.dto.ts
+++ b/backend/src/xp/dto/get-xp.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class GetXpDto {
+  @IsUUID()
+  userId!: string;
+}

--- a/backend/src/xp/processed-event.entity.ts
+++ b/backend/src/xp/processed-event.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('processed_event')
+export class ProcessedEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  eventId!: string;
+
+  @Column({ nullable: true })
+  source?: string;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/xp/stellar-account.entity.ts
+++ b/backend/src/xp/stellar-account.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('stellar_account')
+export class StellarAccount {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ unique: true })
+  stellarAccount!: string; // e.g., G... public address
+
+  @Column({ nullable: true })
+  userId?: string; // internal user uuid or identifier
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/xp/stellar-listener.service.ts
+++ b/backend/src/xp/stellar-listener.service.ts
@@ -1,0 +1,81 @@
+import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { XpService } from './xp.service';
+
+const StellarSdk = require('stellar-sdk');
+
+@Injectable()
+export class StellarListenerService implements OnModuleInit {
+  private readonly logger = new Logger(StellarListenerService.name);
+
+  constructor(private readonly config: ConfigService, private readonly xpService: XpService) {}
+
+  onModuleInit() {
+    this.start();
+  }
+
+  start() {
+    try {
+      const horizon = this.config.get<string>('STELLAR_HORIZON_URL') || 'https://horizon-testnet.stellar.org';
+      const server = new StellarSdk.Server(horizon);
+
+      // Listen to payments stream as a simple example
+      server.payments().cursor('now').stream({
+        onmessage: async (payment: any) => {
+          try {
+            // For native payments or token transfers
+            const type = payment.type; // e.g., "payment"
+            const from = payment.from || payment.source_account;
+            // Use transaction hash as eventId
+            const eventId = payment.transaction_hash || payment.id || `${payment.id}`;
+
+            // Map Stellar payment types to our xp types
+            // Here we treat any payment as 'token_send'
+            const xpEvent = {
+              eventId: `payment:${eventId}`,
+              type: 'token_send',
+              userId: from,
+              data: payment,
+            };
+
+            await this.xpService.handleEvent(xpEvent);
+          } catch (err) {
+            this.logger.error('Error processing payment event', err as Error);
+          }
+        },
+        onerror: (err: any) => {
+          this.logger.error('Stellar payment stream error', err);
+        },
+      });
+
+      // Optionally stream transactions or operations for messages/managed data
+      server.transactions().cursor('now').stream({
+        onmessage: async (tx: any) => {
+          try {
+            // If transactions contain manage_data or memo that indicates a message
+            const eventId = tx.id || tx.hash || tx.paging_token;
+            const memo = tx.memo;
+            if (memo) {
+              const xpEvent = {
+                eventId: `tx:${eventId}`,
+                type: 'message',
+                userId: tx.source_account,
+                data: { memo },
+              };
+              await this.xpService.handleEvent(xpEvent);
+            }
+          } catch (err) {
+            this.logger.error('Error processing transaction event', err as Error);
+          }
+        },
+        onerror: (err: any) => {
+          this.logger.error('Stellar transaction stream error', err);
+        },
+      });
+
+      this.logger.log(`StellarListenerService connected to ${horizon}`);
+    } catch (err) {
+      this.logger.error('Failed to start StellarListenerService', err as Error);
+    }
+  }
+}

--- a/backend/src/xp/xp.controller.spec.ts
+++ b/backend/src/xp/xp.controller.spec.ts
@@ -1,0 +1,54 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { XpController } from './xp.controller';
+import { XpService } from './xp.service';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { StellarAccount } from './stellar-account.entity';
+
+describe('XpController', () => {
+  let controller: XpController;
+
+  beforeEach(async () => {
+    const mockXpService = {
+      getXpForUser: jest.fn().mockResolvedValue(42),
+      addXp: jest.fn().mockResolvedValue({ userId: 'u-1', xpValue: 50 }),
+      handleEvent: jest.fn().mockResolvedValue({ userId: 'u-1', xpValue: 5 }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [XpController],
+      providers: [
+        { provide: XpService, useValue: mockXpService },
+        {
+          provide: getRepositoryToken(StellarAccount),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            create: jest.fn().mockImplementation((v) => v),
+            save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<XpController>(XpController);
+  });
+
+  it('GET /xp/:userId returns xp', async () => {
+    const res = await controller.getXp('u-1');
+    expect(res).toEqual({ userId: 'u-1', xp: 42 });
+  });
+
+  it('POST /xp/add calls service and returns xp', async () => {
+    const body = { userId: 'u-1', amount: 8 } as any;
+    const res = await controller.addXp(body);
+    expect(res).toEqual({ userId: 'u-1', xp: 42 });
+  });
+
+  it('POST /xp/map-account upserts mapping', async () => {
+    const repo: any = (controller as any).stellarAccountRepo;
+    (repo.findOne as jest.Mock).mockResolvedValueOnce(null);
+    const body = { stellarAccount: 'GXXX', userId: 'u-1' } as any;
+    const res = await controller.mapAccount(body);
+    expect(res).toHaveProperty('stellarAccount', 'GXXX');
+    expect(res).toHaveProperty('userId', 'u-1');
+  });
+});

--- a/backend/src/xp/xp.controller.ts
+++ b/backend/src/xp/xp.controller.ts
@@ -1,0 +1,60 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Post,
+  Body,
+  UsePipes,
+  ValidationPipe,
+} from '@nestjs/common';
+import { XpService } from './xp.service';
+import { AddXpDto, StellarEventDto, MapStellarAccountDto } from './dto/add-xp.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { StellarAccount } from './stellar-account.entity';
+
+@Controller('xp')
+export class XpController {
+  constructor(
+    private readonly xpService: XpService,
+    @InjectRepository(StellarAccount)
+    private readonly stellarAccountRepo: Repository<StellarAccount>,
+  ) {}
+
+  @Get(':userId')
+  async getXp(@Param('userId') userId: string) {
+    const xp = await this.xpService.getXpForUser(userId);
+    return { userId, xp };
+  }
+
+  @Post('add')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async addXp(@Body() body: AddXpDto) {
+    await this.xpService.addXp(body.userId, body.amount, body.source);
+    const xp = await this.xpService.getXpForUser(body.userId);
+    return { userId: body.userId, xp };
+  }
+
+  @Post('event')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async handleEvent(@Body() event: StellarEventDto) {
+    const res = await this.xpService.handleEvent(event);
+    return { processed: !!res };
+  }
+
+  @Post('map-account')
+  async mapAccount(@Body() body: MapStellarAccountDto) {
+    // lightweight: find or create a mapping
+    // Controller does a simple upsert via repository
+    // Note: in larger projects this should be handled by a dedicated service
+    const existing = await this.stellarAccountRepo.findOne({ where: { stellarAccount: body.stellarAccount } });
+    if (existing) {
+      existing.userId = body.userId ?? existing.userId;
+      await this.stellarAccountRepo.save(existing);
+      return existing;
+    }
+    const created = this.stellarAccountRepo.create({ stellarAccount: body.stellarAccount, userId: body.userId });
+    await this.stellarAccountRepo.save(created);
+    return created;
+  }
+}

--- a/backend/src/xp/xp.entity.ts
+++ b/backend/src/xp/xp.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn } from 'typeorm';
+
+@Entity('xp')
+export class Xp {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  userId!: string;
+
+  @Column({ type: 'int', default: 0 })
+  xpValue!: number;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/backend/src/xp/xp.module.ts
+++ b/backend/src/xp/xp.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Xp } from './xp.entity';
+import { ProcessedEvent } from './processed-event.entity';
+import { StellarAccount } from './stellar-account.entity';
+import { XpService } from './xp.service';
+import { XpController } from './xp.controller';
+import { StellarListenerService } from './stellar-listener.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Xp, ProcessedEvent, StellarAccount])],
+  providers: [XpService, StellarListenerService],
+  controllers: [XpController],
+  exports: [XpService],
+})
+export class XpModule {}

--- a/backend/src/xp/xp.service.spec.ts
+++ b/backend/src/xp/xp.service.spec.ts
@@ -1,0 +1,214 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Xp } from './xp.entity';
+import { XpService } from './xp.service';
+import { ProcessedEvent } from './processed-event.entity';
+import { StellarAccount } from './stellar-account.entity';
+
+describe('XpService', () => {
+  let service: XpService;
+  let repo: Repository<Xp>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        XpService,
+        {
+          provide: getRepositoryToken(Xp),
+            useValue: {
+              findOne: jest.fn(),
+              create: jest.fn().mockImplementation((v) => v),
+              save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+            },
+        },
+          {
+            provide: getRepositoryToken(StellarAccount),
+            useValue: {
+              findOne: jest.fn().mockResolvedValue(null),
+            },
+          },
+          {
+            provide: getRepositoryToken(ProcessedEvent),
+            useValue: {
+              findOne: jest.fn(),
+              save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+            },
+          },
+          {
+            provide: require('typeorm').DataSource,
+            useValue: {
+              transaction: jest.fn().mockImplementation(async (cb) => cb({
+                findOne: jest.fn().mockResolvedValue(null),
+                create: jest.fn().mockImplementation((v) => v),
+                save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+              })),
+            },
+          },
+          {
+            provide: 'DataSource',
+            useValue: {
+              transaction: jest.fn().mockImplementation(async (cb) => cb({
+                findOne: jest.fn().mockResolvedValue(null),
+                create: jest.fn().mockImplementation((v) => v),
+                save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+              })),
+            },
+          },
+      ],
+    }).compile();
+
+    service = module.get<XpService>(XpService);
+    repo = module.get<Repository<Xp>>(getRepositoryToken(Xp));
+  });
+
+  it('adds xp via processStellarEvent', async () => {
+    (repo.findOne as jest.Mock).mockResolvedValue(null);
+    const res = await service.processStellarEvent({
+      type: 'message',
+      userId: '00000000-0000-0000-0000-000000000000',
+    });
+    expect(res).toBeDefined();
+    expect((repo.save as jest.Mock).mock.calls.length).toBeGreaterThan(0);
+  });
+
+  it('handleEvent is idempotent', async () => {
+    // create a fresh module where the transaction mock simulates processed event exists on second call
+    const processedFind = jest.fn()
+      .mockResolvedValueOnce(null) // first call: not processed
+      .mockResolvedValueOnce({ eventId: 'evt-1' }); // second call: processed
+
+    let processedChecks = 0;
+    const managerSpy = {
+      findOne: jest.fn().mockImplementation(async (entityOrOptions: any, maybeOptions?: any) => {
+        // TypeORM manager.findOne(entity, { where: {...} }) signature
+        const options = maybeOptions ?? (entityOrOptions && entityOrOptions.where ? entityOrOptions : undefined);
+        if (options && options.where && Object.prototype.hasOwnProperty.call(options.where, 'eventId')) {
+          processedChecks += 1;
+          return processedChecks === 1 ? null : { eventId: 'evt-1' };
+        }
+        if (options && options.where && Object.prototype.hasOwnProperty.call(options.where, 'userId')) {
+          return null; // simulate no xp row
+        }
+        return null;
+      }),
+      create: jest.fn().mockImplementation((v) => v),
+      save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+    };
+
+    const dataSourceMock = {
+      transaction: jest.fn().mockImplementation(async (cb) => cb(managerSpy)),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        XpService,
+        {
+          provide: getRepositoryToken(Xp),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            create: jest.fn().mockImplementation((v) => v),
+            save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+          },
+        },
+        {
+          provide: getRepositoryToken(ProcessedEvent),
+          useValue: {
+            findOne: processedFind,
+            save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+          },
+        },
+        {
+          provide: getRepositoryToken(StellarAccount),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+          },
+        },
+        {
+          provide: require('typeorm').DataSource,
+          useValue: dataSourceMock,
+        },
+      ],
+    }).compile();
+
+    const svc = module.get<XpService>(XpService);
+    const xpRepoMock = module.get(getRepositoryToken(Xp));
+
+    // first handling should process and call save
+    await svc.handleEvent({ eventId: 'evt-1', type: 'message', userId: 'u-1' });
+    const callsAfterFirst = (managerSpy.save as jest.Mock).mock.calls.length;
+
+    // second handling should be skipped due to processed event
+    await svc.handleEvent({ eventId: 'evt-1', type: 'message', userId: 'u-1' });
+    const callsAfterSecond = (managerSpy.save as jest.Mock).mock.calls.length;
+
+    // no additional saves should have happened on duplicate event
+    expect(callsAfterSecond).toBe(callsAfterFirst);
+  });
+
+  it('awards XP to mapped internal userId when Stellar account is mapped', async () => {
+    const savedItems: any[] = [];
+    const managerSpy = {
+      findOne: jest.fn().mockImplementation(async (entityOrOptions: any, maybeOptions?: any) => {
+        const options = maybeOptions ?? (entityOrOptions && entityOrOptions.where ? entityOrOptions : undefined);
+        if (options && options.where && Object.prototype.hasOwnProperty.call(options.where, 'eventId')) {
+          return null;
+        }
+        if (options && options.where && Object.prototype.hasOwnProperty.call(options.where, 'userId')) {
+          return null; // simulate no xp row exists for internal user
+        }
+        return null;
+      }),
+      create: jest.fn().mockImplementation((v) => v),
+  save: jest.fn().mockImplementation((...args: any[]) => { const v = args[args.length - 1]; savedItems.push(v); return Promise.resolve(v); }),
+    };
+
+    const dataSourceMock = { transaction: jest.fn().mockImplementation(async (cb) => cb(managerSpy)) };
+
+    const mappedStellarAccount = { stellarAccount: 'GABC', userId: 'internal-123' };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        XpService,
+        {
+          provide: getRepositoryToken(Xp),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            create: jest.fn().mockImplementation((v) => v),
+            save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+          },
+        },
+        {
+          provide: getRepositoryToken(ProcessedEvent),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(null),
+            save: jest.fn().mockImplementation((v) => Promise.resolve(v)),
+          },
+        },
+        {
+          provide: getRepositoryToken(StellarAccount),
+          useValue: {
+            findOne: jest.fn().mockResolvedValue(mappedStellarAccount),
+          },
+        },
+        {
+          provide: require('typeorm').DataSource,
+          useValue: dataSourceMock,
+        },
+      ],
+    }).compile();
+
+    const svc = module.get<XpService>(XpService);
+
+  // handle an event where userId is the Stellar account 'GABC'
+  const res = await svc.handleEvent({ eventId: 'evt-xyz', type: 'message', userId: 'GABC' });
+
+    // the service should have created an XP row for the mapped internal user id
+  expect(managerSpy.create).toHaveBeenCalled();
+    const createdCallHasInternal = (managerSpy.create as jest.Mock).mock.calls.some((call: any[]) => {
+      const maybeObj = call[1];
+      return maybeObj && maybeObj.userId === 'internal-123';
+    });
+    expect(createdCallHasInternal).toBe(true);
+  });
+});

--- a/backend/src/xp/xp.service.ts
+++ b/backend/src/xp/xp.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, DataSource } from 'typeorm';
+import { Xp } from './xp.entity';
+import { ProcessedEvent } from './processed-event.entity';
+import { StellarAccount } from './stellar-account.entity';
+
+@Injectable()
+export class XpService {
+  private readonly logger = new Logger(XpService.name);
+
+  constructor(
+    @InjectRepository(Xp)
+    private readonly xpRepo: Repository<Xp>,
+    @InjectRepository(ProcessedEvent)
+    private readonly processedRepo: Repository<ProcessedEvent>,
+    @InjectRepository(StellarAccount)
+    private readonly stellarAccountRepo: Repository<StellarAccount>,
+    private readonly dataSource: DataSource,
+  ) {}
+
+  async getXpForUser(userId: string): Promise<number> {
+    const xpRow = await this.xpRepo.findOne({ where: { userId } });
+    return xpRow ? xpRow.xpValue : 0;
+  }
+
+  async addXp(userId: string, amount: number, source?: string) {
+    if (amount <= 0) return; // ignore non-positive
+
+    let xpRow = await this.xpRepo.findOne({ where: { userId } });
+    if (!xpRow) {
+      xpRow = this.xpRepo.create({ userId, xpValue: amount });
+    } else {
+      xpRow.xpValue += amount;
+    }
+
+    await this.xpRepo.save(xpRow);
+    this.logger.log(`Added ${amount} XP to ${userId} (source=${source})`);
+    return xpRow;
+  }
+
+  // Example: process a Stellar event payload to award XP
+  async processStellarEvent(event: { type: string; userId: string; data?: any }) {
+    // Basic mapping; could be expanded in repo notes
+    const mapping = {
+      message: 5,
+      token_send: 10,
+    } as Record<string, number>;
+
+    const amount = mapping[event.type] ?? 0;
+    if (amount > 0) {
+      return this.addXp(event.userId, amount, event.type);
+    }
+    return null;
+  }
+
+  // idempotent handler for incoming Stellar events (uses eventId dedup)
+  async handleEvent(event: { eventId: string; type: string; userId: string; data?: any }) {
+    // transactional approach: insert processed_event, if exists -> skip
+    return this.dataSource.transaction(async (manager) => {
+      const processed = await manager.findOne(ProcessedEvent, { where: { eventId: event.eventId } });
+      if (processed) return null; // already handled
+
+      await manager.save(ProcessedEvent, { eventId: event.eventId, source: event.type });
+
+      const mapping = { message: 5, token_send: 10 } as Record<string, number>;
+      const amount = mapping[event.type] ?? 0;
+      if (amount > 0) {
+        // Resolve Stellar account address to internal userId if mapping exists
+        let resolvedUserId = event.userId;
+        try {
+          const mappingRow = await this.stellarAccountRepo.findOne({ where: { stellarAccount: event.userId } });
+          if (mappingRow && mappingRow.userId) resolvedUserId = mappingRow.userId;
+        } catch (e) {
+          // non-fatal; if repo not available in this runtime, fallback to raw userId
+          this.logger.debug('StellarAccount lookup failed, using raw userId');
+        }
+
+        let xpRow = await manager.findOne(Xp, { where: { userId: resolvedUserId } });
+        if (!xpRow) {
+          xpRow = manager.create(Xp, { userId: resolvedUserId, xpValue: amount });
+          const saved = await manager.save(Xp, xpRow);
+          if (saved && !saved.userId) (saved as any).userId = resolvedUserId;
+          return saved;
+        } else {
+          xpRow.xpValue += amount;
+          const saved = await manager.save(Xp, xpRow);
+          if (saved && !saved.userId) (saved as any).userId = resolvedUserId;
+          return saved;
+        }
+      }
+      return null;
+    });
+  }
+}


### PR DESCRIPTION
Adds an XP subsystem that awards and stores user XP from app and Stellar events, with idempotent event processing and Stellar→internal-user mapping; includes API endpoints, validation, unit tests, and a SQL migration.


Closes #11 