### PR TITLE
Title: Add AvatarsModule for NFT Avatar Minting and Storage

### DIFF
--- a/backend/src/Avatars/Services/stellar-nft.service.ts
+++ b/backend/src/Avatars/Services/stellar-nft.service.ts
@@ -1,0 +1,99 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  Server,
+  Keypair,
+  Asset,
+  Operation,
+  TransactionBuilder,
+  Networks,
+  Account,
+  BASE_FEE
+} from 'stellar-sdk';
+
+@Injectable()
+export class StellarNftService {
+  private readonly logger = new Logger(StellarNftService.name);
+  private readonly server: Server;
+  private readonly issuerKeypair: Keypair;
+  private readonly networkPassphrase: string;
+
+  constructor(private configService: ConfigService) {
+    const isTestnet = this.configService.get('STELLAR_NETWORK') === 'testnet';
+    this.server = new Server(
+      isTestnet 
+        ? 'https://horizon-testnet.stellar.org'
+        : 'https://horizon.stellar.org'
+    );
+    this.networkPassphrase = isTestnet ? Networks.TESTNET : Networks.PUBLIC;
+    
+    const issuerSecret = this.configService.get('STELLAR_ISSUER_SECRET');
+    if (!issuerSecret) {
+      throw new Error('STELLAR_ISSUER_SECRET is required');
+    }
+    this.issuerKeypair = Keypair.fromSecret(issuerSecret);
+  }
+
+  async mintNFT(
+    recipientPublicKey: string,
+    assetCode: string,
+    metadata: any
+  ): Promise<{ txId: string; assetCode: string; issuer: string }> {
+    try {
+      // Load issuer account
+      const issuerAccount = await this.server.loadAccount(this.issuerKeypair.publicKey());
+      
+      // Create the NFT asset
+      const nftAsset = new Asset(assetCode, this.issuerKeypair.publicKey());
+      
+      // Build transaction
+      const transaction = new TransactionBuilder(issuerAccount, {
+        fee: BASE_FEE,
+        networkPassphrase: this.networkPassphrase,
+      })
+        .addOperation(
+          Operation.payment({
+            destination: recipientPublicKey,
+            asset: nftAsset,
+            amount: '1', // NFTs typically have amount of 1
+          })
+        )
+        .addOperation(
+          Operation.setOptions({
+            source: this.issuerKeypair.publicKey(),
+            masterWeight: 0, // Lock the asset (makes it truly non-fungible)
+          })
+        )
+        .addOperation(
+          Operation.manageData({
+            name: `${assetCode}_metadata`,
+            value: JSON.stringify(metadata),
+          })
+        )
+        .setTimeout(300)
+        .build();
+
+      // Sign transaction
+      transaction.sign(this.issuerKeypair);
+
+      // Submit transaction
+      const result = await this.server.submitTransaction(transaction);
+      
+      this.logger.log(`NFT minted successfully: ${result.hash}`);
+      
+      return {
+        txId: result.hash,
+        assetCode,
+        issuer: this.issuerKeypair.publicKey(),
+      };
+    } catch (error) {
+      this.logger.error('Error minting NFT:', error);
+      throw new BadRequestException(`Failed to mint NFT: ${error.message}`);
+    }
+  }
+
+  generateUniqueAssetCode(userId: string, level: number): string {
+    const timestamp = Date.now().toString(36);
+    return `AVT${level}${userId.slice(-4)}${timestamp}`.toUpperCase().slice(0, 12);
+  }
+}

--- a/backend/src/Avatars/avatars.controller.ts
+++ b/backend/src/Avatars/avatars.controller.ts
@@ -1,0 +1,98 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  ParseUUIDPipe,
+  UseGuards,
+  Request,
+  HttpStatus,
+  HttpCode,
+} from '@nestjs/common';
+import { 
+  ApiTags, 
+  ApiOperation, 
+  ApiResponse, 
+  ApiParam,
+  ApiBearerAuth,
+  ApiBody,
+} from '@nestjs/swagger';
+import { AvatarsService } from './avatars.service';
+import { CreateAvatarDto } from './dto/create-avatar.dto';
+import { AvatarResponseDto } from './dto/avatar-response.dto';
+// Assuming you have authentication guards
+// import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+
+@ApiTags('Avatars')
+@Controller('avatars')
+// @UseGuards(JwtAuthGuard) // Uncomment if you have auth guards
+export class AvatarsController {
+  constructor(private readonly avatarsService: AvatarsService) {}
+
+  @Post('mint')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiOperation({ summary: 'Mint a new NFT avatar for the authenticated user' })
+  @ApiBearerAuth()
+  @ApiBody({ type: CreateAvatarDto })
+  @ApiResponse({
+    status: 201,
+    description: 'Avatar successfully minted',
+    type: AvatarResponseDto,
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'User already has an active avatar',
+  })
+  @ApiResponse({
+    status: 400,
+    description: 'Invalid input data or Stellar transaction failed',
+  })
+  async mintAvatar(
+    @Body() createAvatarDto: CreateAvatarDto,
+    @Request() req: any, // Replace with your user type
+  ): Promise<AvatarResponseDto> {
+    // Extract user info from request (adjust based on your auth implementation)
+    const userId = req.user?.id || req.user?.userId;
+    const stellarPublicKey = req.user?.stellarPublicKey || req.body.stellarPublicKey;
+    
+    // For demo purposes, you might need to pass stellarPublicKey in the request body
+    // In production, this should come from the authenticated user's profile
+    
+    return this.avatarsService.mintAvatar(userId, createAvatarDto, stellarPublicKey);
+  }
+
+  @Get(':userId')
+  @ApiOperation({ summary: 'Get avatar by user ID' })
+  @ApiParam({
+    name: 'userId',
+    description: 'User UUID',
+    type: 'string',
+    format: 'uuid',
+  })
+  @ApiResponse({
+    status: 200,
+    description: 'Avatar found',
+    type: AvatarResponseDto,
+  })
+  @ApiResponse({
+    status: 404,
+    description: 'Avatar not found',
+  })
+  async getAvatar(
+    @Param('userId', ParseUUIDPipe) userId: string,
+  ): Promise<AvatarResponseDto> {
+    return this.avatarsService.getUserAvatar(userId);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'Get all avatars' })
+  @ApiResponse({
+    status: 200,
+    description: 'List of all avatars',
+    type: [AvatarResponseDto],
+  })
+  async getAllAvatars(): Promise<AvatarResponseDto[]> {
+    return this.avatarsService.getAllAvatars();
+  }
+}

--- a/backend/src/Avatars/avatars.module.ts
+++ b/backend/src/Avatars/avatars.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
+import { AvatarsController } from './avatars.controller';
+import { AvatarsService } from './avatars.service';
+import { StellarNftService } from './services/stellar-nft.service';
+import { Avatar } from './entities/avatar.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([Avatar]),
+    ConfigModule,
+  ],
+  controllers: [AvatarsController],
+  providers: [AvatarsService, StellarNftService],
+  exports: [AvatarsService], // Export if other modules need to use it
+})
+export class AvatarsModule {}

--- a/backend/src/Avatars/avatars.service.ts
+++ b/backend/src/Avatars/avatars.service.ts
@@ -1,0 +1,112 @@
+import { Injectable, NotFoundException, ConflictException, Logger } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Avatar } from './entities/avatar.entity';
+import { CreateAvatarDto } from './dto/create-avatar.dto';
+import { AvatarResponseDto } from './dto/avatar-response.dto';
+import { StellarNftService } from './services/stellar-nft.service';
+
+@Injectable()
+export class AvatarsService {
+  private readonly logger = new Logger(AvatarsService.name);
+
+  constructor(
+    @InjectRepository(Avatar)
+    private avatarRepository: Repository<Avatar>,
+    private stellarNftService: StellarNftService,
+  ) {}
+
+  async mintAvatar(
+    userId: string,
+    createAvatarDto: CreateAvatarDto,
+    userStellarPublicKey: string,
+  ): Promise<AvatarResponseDto> {
+    // Check if user already has an avatar
+    const existingAvatar = await this.avatarRepository.findOne({ 
+      where: { userId, isActive: true } 
+    });
+    
+    if (existingAvatar) {
+      throw new ConflictException('User already has an active avatar');
+    }
+
+    try {
+      // Generate unique asset code
+      const assetCode = this.stellarNftService.generateUniqueAssetCode(
+        userId, 
+        createAvatarDto.level
+      );
+
+      // Mint NFT on Stellar
+      const { txId, issuer } = await this.stellarNftService.mintNFT(
+        userStellarPublicKey,
+        assetCode,
+        createAvatarDto,
+      );
+
+      // Save to database
+      const avatar = this.avatarRepository.create({
+        userId,
+        metadata: createAvatarDto,
+        txId,
+        stellarAssetCode: assetCode,
+        stellarIssuer: issuer,
+      });
+
+      const savedAvatar = await this.avatarRepository.save(avatar);
+      
+      this.logger.log(`Avatar created for user ${userId}: ${savedAvatar.id}`);
+      
+      return this.mapToResponseDto(savedAvatar);
+    } catch (error) {
+      this.logger.error(`Failed to mint avatar for user ${userId}:`, error);
+      throw error;
+    }
+  }
+
+  async getUserAvatar(userId: string): Promise<AvatarResponseDto> {
+    const avatar = await this.avatarRepository.findOne({
+      where: { userId, isActive: true },
+    });
+
+    if (!avatar) {
+      throw new NotFoundException('Avatar not found for this user');
+    }
+
+    return this.mapToResponseDto(avatar);
+  }
+
+  async getAllAvatars(): Promise<AvatarResponseDto[]> {
+    const avatars = await this.avatarRepository.find({
+      where: { isActive: true },
+      order: { createdAt: 'DESC' },
+    });
+
+    return avatars.map(avatar => this.mapToResponseDto(avatar));
+  }
+
+  async deactivateAvatar(userId: string): Promise<void> {
+    const result = await this.avatarRepository.update(
+      { userId, isActive: true },
+      { isActive: false }
+    );
+
+    if (result.affected === 0) {
+      throw new NotFoundException('No active avatar found for this user');
+    }
+  }
+
+  private mapToResponseDto(avatar: Avatar): AvatarResponseDto {
+    return {
+      id: avatar.id,
+      userId: avatar.userId,
+      metadata: avatar.metadata,
+      txId: avatar.txId,
+      stellarAssetCode: avatar.stellarAssetCode,
+      stellarIssuer: avatar.stellarIssuer,
+      isActive: avatar.isActive,
+      createdAt: avatar.createdAt,
+      updatedAt: avatar.updatedAt,
+    };
+  }
+}

--- a/backend/src/Avatars/dto/avatar-response.dto.ts
+++ b/backend/src/Avatars/dto/avatar-response.dto.ts
@@ -1,0 +1,21 @@
+export class AvatarResponseDto {
+  id: string;
+  userId: string;
+  metadata: {
+    name: string;
+    description: string;
+    image: string;
+    level: number;
+    rarity: string;
+    attributes: Array<{
+      trait_type: string;
+      value: string | number;
+    }>;
+  };
+  txId: string;
+  stellarAssetCode: string;
+  stellarIssuer: string;
+  isActive: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/backend/src/Avatars/entities/avatar.entity.ts
+++ b/backend/src/Avatars/entities/avatar.entity.ts
@@ -1,0 +1,80 @@
+import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm';
+
+@Entity('avatars')
+@Index(['userId'], { unique: true }) // One avatar per user
+export class Avatar {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  @Index()
+  userId: string;
+
+  @Column({ type: 'jsonb' })
+  metadata: {
+    name: string;
+    description: string;
+    image: string;
+    level: number;
+    rarity: 'common' | 'rare' | 'epic' | 'legendary';
+    attributes: Array<{
+      trait_type: string;
+      value: string | number;
+    }>;
+  };
+
+  @Column({ type: 'varchar', length: 64 })
+  @Index()
+  txId: string; // Stellar transaction ID
+
+  @Column({ type: 'varchar', length: 56 })
+  stellarAssetCode: string; // Stellar asset code
+
+  @Column({ type: 'varchar', length: 56 })
+  stellarIssuer: string; // Stellar issuer account
+
+  @Column({ type: 'boolean', default: true })
+  isActive: boolean;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}
+
+// src/avatars/dto/create-avatar.dto.ts
+import { IsString, IsNumber, IsEnum, IsArray, ValidateNested, IsUrl, Min, Max } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class AttributeDto {
+  @IsString()
+  trait_type: string;
+
+  @IsString()
+  value: string | number;
+}
+
+export class CreateAvatarDto {
+  @IsString()
+  name: string;
+
+  @IsString()
+  description: string;
+
+  @IsUrl()
+  image: string;
+
+  @IsNumber()
+  @Min(1)
+  @Max(100)
+  level: number;
+
+  @IsEnum(['common', 'rare', 'epic', 'legendary'])
+  rarity: 'common' | 'rare' | 'epic' | 'legendary';
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AttributeDto)
+  attributes: AttributeDto[];
+}

--- a/backend/src/Avatars/tests/avatars.service.spec.ts
+++ b/backend/src/Avatars/tests/avatars.service.spec.ts
@@ -1,0 +1,155 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConflictException, NotFoundException } from '@nestjs/common';
+import { AvatarsService } from '../../src/avatars/avatars.service';
+import { StellarNftService } from '../../src/avatars/services/stellar-nft.service';
+import { Avatar } from '../../src/avatars/entities/avatar.entity';
+import { CreateAvatarDto } from '../../src/avatars/dto/create-avatar.dto';
+
+describe('AvatarsService', () => {
+  let service: AvatarsService;
+  let repository: Repository<Avatar>;
+  let stellarService: StellarNftService;
+
+  const mockRepository = {
+    findOne: jest.fn(),
+    create: jest.fn(),
+    save: jest.fn(),
+    find: jest.fn(),
+    update: jest.fn(),
+  };
+
+  const mockStellarService = {
+    generateUniqueAssetCode: jest.fn(),
+    mintNFT: jest.fn(),
+  };
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AvatarsService,
+        {
+          provide: getRepositoryToken(Avatar),
+          useValue: mockRepository,
+        },
+        {
+          provide: StellarNftService,
+          useValue: mockStellarService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<AvatarsService>(AvatarsService);
+    repository = module.get<Repository<Avatar>>(getRepositoryToken(Avatar));
+    stellarService = module.get<StellarNftService>(StellarNftService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('mintAvatar', () => {
+    const createAvatarDto: CreateAvatarDto = {
+      name: 'Test Avatar',
+      description: 'A test avatar',
+      image: 'https://example.com/avatar.png',
+      level: 1,
+      rarity: 'common',
+      attributes: [{ trait_type: 'background', value: 'blue' }],
+    };
+
+    const userId = 'user-123';
+    const stellarPublicKey = 'STELLAR_PUBLIC_KEY';
+
+    it('should successfully mint an avatar', async () => {
+      // Setup mocks
+      mockRepository.findOne.mockResolvedValue(null); // No existing avatar
+      mockStellarService.generateUniqueAssetCode.mockReturnValue('AVTTEST123');
+      mockStellarService.mintNFT.mockResolvedValue({
+        txId: 'stellar-tx-id',
+        assetCode: 'AVTTEST123',
+        issuer: 'STELLAR_ISSUER',
+      });
+
+      const mockAvatar = {
+        id: 'avatar-id',
+        userId,
+        metadata: createAvatarDto,
+        txId: 'stellar-tx-id',
+        stellarAssetCode: 'AVTTEST123',
+        stellarIssuer: 'STELLAR_ISSUER',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockRepository.create.mockReturnValue(mockAvatar);
+      mockRepository.save.mockResolvedValue(mockAvatar);
+
+      // Execute
+      const result = await service.mintAvatar(userId, createAvatarDto, stellarPublicKey);
+
+      // Verify
+      expect(result).toEqual({
+        id: 'avatar-id',
+        userId,
+        metadata: createAvatarDto,
+        txId: 'stellar-tx-id',
+        stellarAssetCode: 'AVTTEST123',
+        stellarIssuer: 'STELLAR_ISSUER',
+        isActive: true,
+        createdAt: expect.any(Date),
+        updatedAt: expect.any(Date),
+      });
+
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { userId, isActive: true }
+      });
+      expect(mockStellarService.mintNFT).toHaveBeenCalledWith(
+        stellarPublicKey,
+        'AVTTEST123',
+        createAvatarDto
+      );
+    });
+
+    it('should throw ConflictException if user already has an avatar', async () => {
+      mockRepository.findOne.mockResolvedValue({ id: 'existing-avatar' });
+
+      await expect(
+        service.mintAvatar(userId, createAvatarDto, stellarPublicKey)
+      ).rejects.toThrow(ConflictException);
+    });
+  });
+
+  describe('getUserAvatar', () => {
+    it('should return user avatar', async () => {
+      const mockAvatar = {
+        id: 'avatar-id',
+        userId: 'user-123',
+        metadata: { name: 'Test Avatar' },
+        txId: 'stellar-tx-id',
+        stellarAssetCode: 'AVTTEST123',
+        stellarIssuer: 'STELLAR_ISSUER',
+        isActive: true,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockRepository.findOne.mockResolvedValue(mockAvatar);
+
+      const result = await service.getUserAvatar('user-123');
+
+      expect(result).toEqual(mockAvatar);
+      expect(mockRepository.findOne).toHaveBeenCalledWith({
+        where: { userId: 'user-123', isActive: true }
+      });
+    });
+
+    it('should throw NotFoundException if avatar not found', async () => {
+      mockRepository.findOne.mockResolvedValue(null);
+
+      await expect(service.getUserAvatar('user-123')).rejects.toThrow(NotFoundException);
+    });
+  });
+});


### PR DESCRIPTION


Description:
This PR introduces the AvatarsModule, enabling users to mint and retrieve NFT avatars tied to their user level, supporting Whisper’s goal of a personalized, on-chain identity.

Key Features:

AvatarsModule created with Avatar entity (id, userId, metadata, txId).

Controller with two endpoints:

POST /avatars/mint: Mint a new avatar NFT.

GET /avatars/:userId: Retrieve a user's avatar.

Service to handle:

Stellar NFT minting.

PostgreSQL persistence.

DTOs for input validation and metadata structure.

Tests for avatar minting and retrieval.

Acceptance Criteria:

Avatars are minted as Stellar NFTs and stored in PostgreSQL.

API endpoints return avatar data as expected.

Metadata is validated before minting.

Community Notes:

Let’s design some dope avatars — feel free to share concepts or ideas in the repo!