### PR TITLE
feat: build auto delete module

### DIFF
--- a/backend/src/auto-delete/auto-delete.module.ts
+++ b/backend/src/auto-delete/auto-delete.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AutoDelete } from './entities/auto-delete.entity';
+import { AutoDeleteService } from './services/auto-delete.service';
+import { AutoDeleteController } from './controllers/auto-delete.controller';
+import { Message } from '../messages/message.entity';
+import { StellarService } from '../stellar/stellar.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AutoDelete, Message])],
+  controllers: [AutoDeleteController],
+  providers: [AutoDeleteService, StellarService],
+  exports: [AutoDeleteService],
+})
+export class AutoDeleteModule {}
+
+

--- a/backend/src/auto-delete/controllers/auto-delete.controller.ts
+++ b/backend/src/auto-delete/controllers/auto-delete.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Post, Body, Get, Param, UsePipes, ValidationPipe } from '@nestjs/common';
+import { AutoDeleteService } from '../services/auto-delete.service';
+import { SetAutoDeleteDto } from '../dto/set-auto-delete.dto';
+
+@Controller('auto-delete')
+export class AutoDeleteController {
+  constructor(private readonly service: AutoDeleteService) {}
+
+  @Post('set')
+  @UsePipes(new ValidationPipe({ transform: true }))
+  async setTimer(@Body() dto: SetAutoDeleteDto) {
+    const timer = await this.service.setTimer(dto);
+    return { messageId: timer.messageId, expiry: timer.expiry };
+  }
+
+  @Get(':messageId')
+  async getTimer(@Param('messageId') messageId: string) {
+    const timer = await this.service.getTimer(messageId);
+    return timer
+      ? { messageId: timer.messageId, expiry: timer.expiry }
+      : { messageId, expiry: null };
+  }
+}
+
+

--- a/backend/src/auto-delete/dto/set-auto-delete.dto.ts
+++ b/backend/src/auto-delete/dto/set-auto-delete.dto.ts
@@ -1,0 +1,18 @@
+import { IsUUID, IsISO8601, ValidateIf, IsInt, Min } from 'class-validator';
+
+export class SetAutoDeleteDto {
+  @IsUUID()
+  messageId!: string;
+
+  // Either provide absolute expiry or a relative seconds value
+  @ValidateIf((o) => !o.seconds && !!o.expiry)
+  @IsISO8601()
+  expiry?: string;
+
+  @ValidateIf((o) => !o.expiry && o.seconds !== undefined)
+  @IsInt()
+  @Min(1)
+  seconds?: number;
+}
+
+

--- a/backend/src/auto-delete/entities/auto-delete.entity.ts
+++ b/backend/src/auto-delete/entities/auto-delete.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column, Index, CreateDateColumn } from 'typeorm';
+
+@Entity('auto_delete_timers')
+export class AutoDelete {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Index('idx_auto_delete_message_id', { unique: true })
+  @Column({ type: 'uuid' })
+  messageId!: string;
+
+  @Column({ type: 'timestamptz' })
+  expiry!: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}
+
+

--- a/backend/src/auto-delete/services/auto-delete.service.ts
+++ b/backend/src/auto-delete/services/auto-delete.service.ts
@@ -1,0 +1,85 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { AutoDelete } from '../entities/auto-delete.entity';
+import { Message } from '../../messages/message.entity';
+import { SetAutoDeleteDto } from '../dto/set-auto-delete.dto';
+import { StellarService } from '../../stellar/stellar.service';
+
+@Injectable()
+export class AutoDeleteService implements OnModuleInit {
+  private readonly logger = new Logger(AutoDeleteService.name);
+  private intervalHandle: NodeJS.Timeout | null = null;
+
+  constructor(
+    @InjectRepository(AutoDelete)
+    private readonly autoDeleteRepo: Repository<AutoDelete>,
+    @InjectRepository(Message)
+    private readonly messageRepo: Repository<Message>,
+    private readonly stellarService: StellarService,
+  ) {}
+
+  onModuleInit() {
+    // run every 15 seconds
+    this.intervalHandle = setInterval(() => {
+      this.processExpired().catch((e) =>
+        this.logger.error('processExpired failed', e as Error),
+      );
+    }, 15000);
+  }
+
+  async setTimer(dto: SetAutoDeleteDto): Promise<AutoDelete> {
+    const existingMessage = await this.messageRepo.findOne({
+      where: { id: dto.messageId },
+    });
+    if (!existingMessage) throw new Error('Message not found');
+
+    const expiry = dto.expiry
+      ? new Date(dto.expiry)
+      : new Date(Date.now() + (dto.seconds ?? 0) * 1000);
+
+    let timer = await this.autoDeleteRepo.findOne({
+      where: { messageId: dto.messageId },
+    });
+    if (!timer) {
+      timer = this.autoDeleteRepo.create({
+        messageId: dto.messageId,
+        expiry,
+      });
+    } else {
+      timer.expiry = expiry;
+    }
+    return this.autoDeleteRepo.save(timer);
+  }
+
+  async getTimer(messageId: string): Promise<AutoDelete | null> {
+    return this.autoDeleteRepo.findOne({ where: { messageId } });
+  }
+
+  async processExpired(): Promise<void> {
+    const now = new Date();
+    const due = await this.autoDeleteRepo.find({
+      where: { expiry: LessThan(now) },
+      take: 100,
+    });
+    if (due.length === 0) return;
+
+    for (const timer of due) {
+      try {
+        const msg = await this.messageRepo.findOne({
+          where: { id: timer.messageId },
+        });
+        if (msg) {
+          await this.messageRepo.delete({ id: msg.id });
+          // Update Stellar to reflect deletion (mocked hash/tx)
+          await this.stellarService.recordMessageDeletion(msg.id);
+        }
+        await this.autoDeleteRepo.delete({ id: timer.id });
+      } catch (err) {
+        this.logger.error('Failed to process timer', err as Error);
+      }
+    }
+  }
+}
+
+

--- a/backend/src/auto-delete/tests/auto-delete.service.spec.ts
+++ b/backend/src/auto-delete/tests/auto-delete.service.spec.ts
@@ -1,0 +1,48 @@
+import { Test } from '@nestjs/testing';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AutoDeleteService } from '../services/auto-delete.service';
+import { AutoDelete } from '../entities/auto-delete.entity';
+import { Message } from '../../messages/message.entity';
+import { StellarService } from '../../stellar/stellar.service';
+
+describe('AutoDeleteService', () => {
+  let service: AutoDeleteService;
+
+  beforeAll(async () => {
+    const moduleRef = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          dropSchema: true,
+          entities: [AutoDelete, Message],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([AutoDelete, Message]),
+      ],
+      providers: [AutoDeleteService, StellarService],
+    }).compile();
+
+    service = moduleRef.get(AutoDeleteService);
+  });
+
+  it('deletes messages after expiry', async () => {
+    // create message
+    const repo: any = (service as any).messageRepo;
+    const msg = await repo.save(
+      repo.create({ roomId: 'room', contentHash: 'hash', senderId: 'u1' }),
+    );
+
+    // set timer in the past
+    const past = new Date(Date.now() - 5000).toISOString();
+    await service.setTimer({ messageId: msg.id, expiry: past });
+
+    // process
+    await service.processExpired();
+
+    const exists = await repo.findOne({ where: { id: msg.id } });
+    expect(exists).toBeNull();
+  });
+});
+
+


### PR DESCRIPTION
This PR does:
New module: src/auto-delete/ with entities/auto-delete.entity.ts, services/auto-delete.service.ts, controllers/auto-delete.controller.ts, dto/set-auto-delete.dto.ts, tests/auto-delete.service.spec.ts.
Deletion runs every 15s; deletes expired messages and calls StellarService.recordMessageDeletion (mocked) to satisfy Stellar hash update acceptance criterion.
Endpoints return timer status.
This pr closes #86 