### PR TITLE
feat(challenges): implement participation tracking and Stellar rewards

### DIFF
--- a/backend/src/challenges/challenges.module.ts
+++ b/backend/src/challenges/challenges.module.ts
@@ -1,15 +1,22 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ConfigModule } from '@nestjs/config';
-import { ChallengesController } from './challenges.controller';
-import { ChallengesService } from './services/challenges.service';
+
 import { Challenge } from './entities/challenge.entity';
-import { ChallengeParticipation } from './entities/challenge-participation.entity';
+import { ChallengeProgress } from './entities/challenge-progress.entity';
+
+import { ChallengesService } from './challenges.service';
+import { ChallengesController } from './challenges.controller';
+
+import { UsersModule } from '../users/users.module';
+import { AuthModule } from '../auth/auth.module';
+import { StellarModule } from '../stellar/stellar.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Challenge, ChallengeParticipation]),
-    ConfigModule,
+    TypeOrmModule.forFeature([Challenge, ChallengeProgress]),
+    forwardRef(() => UsersModule),   
+    forwardRef(() => AuthModule),    
+    StellarModule,                   
   ],
   controllers: [ChallengesController],
   providers: [ChallengesService],

--- a/backend/src/challenges/entities/challenge-participation.entity.ts
+++ b/backend/src/challenges/entities/challenge-participation.entity.ts
@@ -1,14 +1,25 @@
-import { Entity, PrimaryGeneratedColumn, Column, CreateDateColumn, UpdateDateColumn, Index, ManyToOne, JoinColumn } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+} from 'typeorm';
 import { Challenge } from './challenge.entity';
 
 export enum ParticipationStatus {
   ACTIVE = 'active',
   COMPLETED = 'completed',
   FAILED = 'failed',
-  ABANDONED = 'abandoned'
+  ABANDONED = 'abandoned',
 }
 
 @Entity('challenge_participations')
+@Unique(['userId', 'challengeId'])
 @Index(['userId'])
 @Index(['challengeId'])
 @Index(['status'])
@@ -26,7 +37,7 @@ export class ChallengeParticipation {
   @Column({
     type: 'enum',
     enum: ParticipationStatus,
-    default: ParticipationStatus.ACTIVE
+    default: ParticipationStatus.ACTIVE,
   })
   status!: ParticipationStatus;
 
@@ -45,7 +56,9 @@ export class ChallengeParticipation {
   @Column({ length: 100, nullable: true })
   stellarTransactionId?: string;
 
-  @ManyToOne(() => Challenge, (challenge) => challenge.participations, { onDelete: 'CASCADE' })
+  @ManyToOne(() => Challenge, (challenge) => challenge.participations, {
+    onDelete: 'CASCADE',
+  })
   @JoinColumn({ name: 'challengeId' })
   challenge!: Challenge;
 


### PR DESCRIPTION
This PR implements the Community Challenges participation system as part of Build Community Challenges for Engagement.
Users can now join challenges, track their progress, and receive Stellar token rewards upon completion.

Entities
Added ChallengeParticipation entity:
Tracks per-user progress (progress, progressData).
Enforces uniqueness (userId + challengeId).
Stores reward payout audit fields (rewardEarned, stellarTransactionId).

Services
Extended ChallengesService:
createChallenge – Admin creates new challenge.
joinChallenge – User joins challenge.
updateProgress – Track challenge progress and auto-complete when goal is met.
Integrated with StellarService to distribute rewards securely.

Database
Added TypeORM migration to create challenge_participations table.
Integration
Connected ChallengesModule with StellarModule for reward distribution.
Ensured auth enforcement via existing controller + DTOs.

Acceptance Criteria ✅
Challenges stored in PostgreSQL.
Users can join challenges once (unique per challenge).
Progress tracked and persisted.
Rewards distributed via Stellar (XLM or custom asset).
Transaction IDs stored for audit purposes.
Controller endpoints protected by auth.

Closes #168 